### PR TITLE
Remove Experience and chart sections

### DIFF
--- a/app/(landing)/Main.tsx
+++ b/app/(landing)/Main.tsx
@@ -11,8 +11,6 @@ import SectionContainer from '@/components/SectionContainer'
 import RecentPosts from '@/components/RecentPosts'
 import Hero from '@/components/landing/Hero'
 import { Technologies } from '@/components/landing/Technologies'
-import { Experience } from '@/components/landing/Experience'
-import { GithubCal } from '@/components/landing/GithubCal'
 import { Separator } from '@/components/ui/separator'
 import { MeteorsDemo } from '@/components/landing/GlitchyCards'
 export default function Home({ posts }) {
@@ -26,16 +24,6 @@ export default function Home({ posts }) {
         <SectionContainer>
           <Separator />
           <Technologies />
-        </SectionContainer>
-        <SectionContainer>
-          <Separator />
-          <Experience />
-        </SectionContainer>
-        <SectionContainer>
-          <Separator />
-          <Suspense fallback={<LuLoader2 className="mx-auto my-10 h-4 w-4 animate-spin" />}>
-            <GithubCal />
-          </Suspense>
         </SectionContainer>
         <SectionContainer>
           <Separator />


### PR DESCRIPTION
## Summary
- remove `Experience` and GitHub chart sections from landing page

## Testing
- `yarn lint` *(fails: network access required)*