### PR TITLE
Fix RSS JSON import and tsconfig cleanup

### DIFF
--- a/scripts/rss.mjs
+++ b/scripts/rss.mjs
@@ -1,9 +1,11 @@
-import { writeFileSync, mkdirSync } from 'fs'
+import { writeFileSync, mkdirSync, readFileSync } from 'fs'
 import path from 'path'
 import { slug } from 'github-slugger'
 import { escape } from 'pliny/utils/htmlEscaper.js'
 import siteMetadata from '../data/siteMetadata.js'
-import tagData from '../app/tag-data.json' assert { type: 'json' }
+const tagData = JSON.parse(
+  readFileSync(path.join(process.cwd(), 'app', 'tag-data.json'), 'utf8')
+)
 import { allBlogs } from '../.contentlayer/generated/index.mjs'
 import { sortPosts } from 'pliny/utils/contentlayer.js'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,6 @@
     ".contentlayer/generated",
     ".contentlayer/generated/**/*.json",
     ".next/types/**/*.ts"
-, "components/mdx/d"  ],
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- switch rss.mjs from JSON import assertions to `fs.readFileSync`
- remove stray `components/mdx/d` entry from tsconfig include array

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com/3.6.1/packages/yarnpkg-cli/bin/yarn.js)*