### PR TITLE
Move resend init into handler

### DIFF
--- a/app/api/email/route.ts
+++ b/app/api/email/route.ts
@@ -3,9 +3,13 @@ import { Resend } from 'resend'
 import { render } from '@react-email/render'
 import { env } from '@/env.mjs'
 
-const resend = new Resend(env.RESEND_TOKEN)
+export const runtime = 'nodejs'
 
 export async function POST() {
+  if (!env.RESEND_TOKEN) {
+    return Response.json({ error: 'RESEND_TOKEN not configured' }, { status: 500 })
+  }
+  const resend = new Resend(env.RESEND_TOKEN)
   try {
     const { data, error } = await resend.emails.send({
       from: 'Acme <onboarding@resend.dev>',


### PR DESCRIPTION
## Summary
- always run email route on Node by exporting runtime
- initialize Resend inside POST handler and check for missing token

## Testing
- `yarn lint` *(fails: fetch failed because offline)*