### PR TITLE
Set dark mode as default theme

### DIFF
--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -7,7 +7,7 @@ const siteMetadata = {
   headerTitle: 'Dexter Mehta',
   description: `A personal blog where I write about software engineering and my developer journey. Also, it's my portfolio.`,
   language: 'en-us',
-  theme: 'system', // system, dark or light
+  theme: 'dark', // system, dark or light
   siteUrl: 'http://localhost:3000',
 
   siteRepo: 'https://github.com/Dexter2099/dexter-personal-site',


### PR DESCRIPTION
## Summary
- start the site in dark mode by setting the `theme` value to `'dark'`

## Testing
- `yarn lint` *(fails: fetch failed due to missing network access)*