### PR TITLE
Add Mining Gym project card

### DIFF
--- a/data/mainData.ts
+++ b/data/mainData.ts
@@ -108,6 +108,15 @@ export let projectsData: Project[] = [
     builtWith: ['Python', 'PyTorch', 'Grad-CAM'],
   },
   {
+    type: 'work',
+    title: 'Mining Gym',
+    description:
+      'A configurable benchmarking environment for optimizing truck dispatch scheduling in open-pit mining using Reinforcement Learning.',
+    imgSrc: '/static/images/projects/7.jpg',
+    repo: 'https://github.com/Dexter2099/Mining-Gym',
+    builtWith: ['Python', 'Codex', 'Prompt Engineering'],
+  },
+  {
     type: 'self',
     title: 'Personal website',
     imgSrc: '/static/images/projects/6.jpg',


### PR DESCRIPTION
## Summary
- add Mining Gym project entry in the project data list

## Testing
- `yarn lint` *(fails: Couldn't find node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_684667de1848832c8d57811671e06e70