### PR TITLE
Remove unused project type header

### DIFF
--- a/app/(landing)/projects/page.tsx
+++ b/app/(landing)/projects/page.tsx
@@ -9,7 +9,6 @@ export const metadata = genPageMetadata({ title: 'Projects' })
 export default async function Projects() {
   const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
   // await delay(10000)
-  const workProjects = projectsData.filter(({ type }) => type === 'work')
   return (
     <>
       <SectionContainer>
@@ -24,9 +23,8 @@ export default async function Projects() {
           </div>
           <Separator />
           <div className="py-12">
-            <h3 className="mb-4 text-3xl font-extrabold leading-9 tracking-tight">Work</h3>
             <div className="-m-4 grid grid-cols-1 gap-2 md:grid-cols-2">
-              {workProjects.map((project) => (
+              {projectsData.map((project) => (
                 <ProjectCard key={project.title} project={project} />
               ))}
             </div>


### PR DESCRIPTION
## Summary
- show all projects on the Projects page
- drop the `Work` heading and associated filtering

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68468210eaec832ca7e5311d3ff817fb